### PR TITLE
Replace "/" in attachment names with "_" when creating filename.

### DIFF
--- a/pyFCC/archive.py
+++ b/pyFCC/archive.py
@@ -142,7 +142,7 @@ def fetch_and_pack(attachments, dir_name, referer):
 		r = s.get(fcc_url + url, headers=dict(Referer=referer))
 
 		extension = r.headers['content-type'].split('/')[-1]
-		filename = name + '.' + extension
+		filename = name.replace('/', '_') + '.' + extension
 		print("Writing %s" % filename)
 		with open(dir_name + '/' + filename, 'wb') as handle:
 			for chunk in r.iter_content():


### PR DESCRIPTION
update_archive.py blew up when running on FCC ID "OWS-NIC511-03" when it got to an attachment named "Label Location/Info". I've proposed replacing the "/" with a "_". I'm sure there's other characters that should be escaped, but I'll leave that to others.